### PR TITLE
Fix for build breakage on Windows in coreutils

### DIFF
--- a/mods/coreutils/utils.cpp
+++ b/mods/coreutils/utils.cpp
@@ -16,8 +16,8 @@
 namespace fs = std::experimental::filesystem;
 
 #ifdef _WIN32
-#include <ShellApi.h>
 #include <windows.h>
+#include <ShellApi.h>
 #else
 #include <sys/wait.h>
 #endif


### PR DESCRIPTION
- Swap order of windows.h and ShellApi.h includes